### PR TITLE
Produce more useful warnings when failing to load analysis files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "json"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,16 +170,17 @@ dependencies = [
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fst 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-data 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-data 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rls-data"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -297,6 +303,7 @@ dependencies = [
 "checksum fst 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d94485a00b1827b861dd9d1a2cc9764f9044d4c535514c0760a5a2012ef3399f"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
+"checksum json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9ad0485404155f45cce53a40d4b2d6ac356418300daed05273d9e26f91c390be"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
@@ -308,7 +315,7 @@ dependencies = [
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13c93d55961981ba9226a213b385216f83ab43bd6ac53ab16b2eeb47e337cf4e"
 "checksum regex-syntax 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05b06a75f5217880fc5e905952a42750bf44787e56a6c6d6852ed0992f5e1d54"
-"checksum rls-data 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd20763e1c60ae8945384c8a8fa4ac44f8afa7b0a817511f5e8927e5d24f988"
+"checksum rls-data 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d186e79f9fc839876ddf327f7603f8a6287c03415904ddce93a49d490eb6bd43"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91b52877572087400e83d24b9178488541e3d535259e04ff17a63df1e5ceff59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,12 @@ exclude = [
 [dependencies]
 rustc-serialize = "0.3"
 log = "0.4"
-rls-data = "= 0.16"
+rls-data = "= 0.17"
 rls-span = "0.4"
 derive-new = "0.5"
 fst = { version = "0.3", default-features = false }
 itertools = "0.7.3"
+json = "0.11.13"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/examples/print-crate-id.rs
+++ b/examples/print-crate-id.rs
@@ -1,0 +1,53 @@
+extern crate rls_analysis;
+extern crate env_logger;
+
+use rls_analysis::{AnalysisHost, AnalysisLoader, SearchDirectory};
+use std::path::{Path, PathBuf};
+use std::env;
+
+#[derive(Clone)]
+pub struct Loader {
+    deps_dir: PathBuf,
+}
+
+impl Loader {
+    pub fn new(deps_dir: PathBuf) -> Self {
+        Self { deps_dir }
+    }
+}
+
+impl AnalysisLoader for Loader {
+    fn needs_hard_reload(&self, _: &Path) -> bool {
+        true
+    }
+
+    fn fresh_host(&self) -> AnalysisHost<Self> {
+        AnalysisHost::new_with_loader(self.clone())
+    }
+
+    fn set_path_prefix(&mut self, _: &Path) {}
+
+    fn abs_path_prefix(&self) -> Option<PathBuf> {
+        None
+    }
+    fn search_directories(&self) -> Vec<SearchDirectory> {
+        vec![SearchDirectory {
+            path: self.deps_dir.clone(),
+            prefix_rewrite: None,
+        }]
+    }
+}
+
+fn main() {
+    env_logger::init();
+    if env::args().len() < 2 {
+        println!("Usage: print-crate-id <save-analysis-dir>");
+        std::process::exit(1);
+    }
+    let loader = Loader::new(PathBuf::from(env::args().nth(1).unwrap()));
+    let crates = rls_analysis::read_analysis_from_files(&loader, Default::default(), &[]);
+
+    for krate in &crates {
+        println!("Crate {:?} data version {:?}", krate.id, krate.analysis.version);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ extern crate rls_span as span;
 extern crate rustc_serialize;
 extern crate fst;
 extern crate itertools;
+extern crate json;
 
 mod analysis;
 mod raw;


### PR DESCRIPTION
This uses the new rls-data to also check for version mismatches in case
of failures. Additionally it upgrades the info! messages to warn!
messages since that seems more appropriate, and adds an example program
that can be used to exercise the code in question.